### PR TITLE
link global env.conf file into env dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ command configured here.
 Use this to (for example) decrypt secrets committed to your
 puppet code using a private key only available on puppet masters.
 
+## link_env_conf
+
+Since 3.7 specifying `modulepath` in puppet.conf is not allowed with
+directory environments. It's value however doesn't often change between
+environments so it does not make sense to keep environment.conf file in
+every branch.
+
+Setting `link_env_conf` to true will make puppetupdate link (if present)
+/etc/puppet/environment.conf into every environment directory if it's not
+already there.
+
+This allows having single /etc/puppet/environment.conf:
+
+```
+modulepath = modules:vendor/modules:$basemodulepath
+```
+
 # Installation
 
 Checkout, then just run:


### PR DESCRIPTION
modulepath in puppet 3.7 is deprecated and in 3.7.4 generates critical error, it's value however doesn't really change between environments

this pr allows linking environment.conf from global confdir into each env folder