### PR TITLE
Major rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ mcollective-puppet-update-application*
 /mcollective
 /tmp
 spec/server.cfg
+.bundle
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ mcollective-puppet-update-application*
 .ruby-version
 .ruby-gemset
 
+/mcollective
+/tmp
+spec/server.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ mcollective-puppet-update-application*
 spec/server.cfg
 .bundle
 *.swp
+/vendor

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gem 'mcollective-test',
   :ref => "69ca8a748361fb04323712ac8a4e62a791016c4e",
   :require => 'mcollective/test'
 gem 'rspec'
+gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'mcollective-client'
-gem 'mcollective-test'
-gem 'rspec', '~> 2.11.0'
-gem 'mocha', '~> 0.10.0'
+gem 'mcollective-test',
+  :git => "git@github.com:keymone/mcollective-test.git",
+  :ref => "69ca8a748361fb04323712ac8a4e62a791016c4e",
+  :require => 'mcollective/test'
+gem 'rspec'

--- a/Rakefile
+++ b/Rakefile
@@ -7,10 +7,8 @@ RSpec::Core::RakeTask.new(:spec) do |t|
   t.pattern = 'spec/**/*_spec.rb'
 end
 
-desc "Run lint (Rubocop)"
-task :lint do
-  sh "/var/lib/gems/1.9.1/bin/rubocop --require rubocop/formatter/checkstyle_formatter "\
-     "--format RuboCop::Formatter::CheckstyleFormatter --out tmp/checkstyle.xml"
-end
+require 'rubocop/rake_task'
 
-task :default => %w(spec lint)
+RuboCop::RakeTask.new
+
+task :default => %w(spec)

--- a/agent/puppetupdate.ddl
+++ b/agent/puppetupdate.ddl
@@ -27,16 +27,12 @@ action "update", :description => "Update the branch to a specific revision" do
     :validation  => ".+",
     :maxlength   => 255
 
-  output :from,
-    :description => "The sha we updated from",
-    :display_as  => "From"
-
-  output :to,
-    :description => "The sha we updated to",
-    :display_as  => "To"
+  output :changes
+    :description => "List of updates in form [ref, from, to, link_env, post_checkout]",
+    :display_as  => "Changes"
 
   output :status,
-    :description => "The status of the git pull",
+    :description => "The status of the update",
     :display_as  => "Pull Status"
 end
 
@@ -44,7 +40,7 @@ action "update_all", :description => "Update all branches on the puppetmaster" d
   display :always
 
   output :status,
-    :description => "The status of the git pull",
+    :description => "The status of the update",
     :display_as  => "Pull Status"
 end
 

--- a/agent/puppetupdate.ddl
+++ b/agent/puppetupdate.ddl
@@ -27,7 +27,7 @@ action "update", :description => "Update the branch to a specific revision" do
     :validation  => ".+",
     :maxlength   => 255
 
-  output :changes
+  output :changes,
     :description => "List of updates in form [ref, from, to, link_env, post_checkout]",
     :display_as  => "Changes"
 

--- a/agent/puppetupdate.ddl
+++ b/agent/puppetupdate.ddl
@@ -27,15 +27,6 @@ action "update", :description => "Update the branch to a specific revision" do
     :validation  => ".+",
     :maxlength   => 255
 
-  input :cleanup,
-    :description => "cleanup old branches [deprecated]",
-    :display_as  => "cleanup old branches after updating [deprecated]",
-    :optional    => true,
-    :type        => :string,
-    :prompt      => "Cleanup (yes/no)",
-    :validation  => ".+",
-    :maxlength   => 3
-
   output :from,
     :description => "The sha we updated from",
     :display_as  => "From"
@@ -51,15 +42,6 @@ end
 
 action "update_all", :description => "Update all branches on the puppetmaster" do
   display :always
-
-  input :cleanup,
-    :description => "cleanup old branches",
-    :display_as  => "cleanup old branches after updating",
-    :optional    => true,
-    :type        => :string,
-    :prompt      => "Cleanup (yes/no)",
-    :validation  => ".+",
-    :maxlength   => 3
 
   output :status,
     :description => "The status of the git pull",

--- a/agent/puppetupdate.rb
+++ b/agent/puppetupdate.rb
@@ -55,7 +55,7 @@ module MCollective
         whilst_locked do
           updated_refs = update_bare_repo
           drop_bad_dirs
-          branches_in_repo_to_sync.each {|branch| update_branch(branch) }
+          branches_in_repo_to_sync(updated_refs).each {|branch| update_branch(branch) }
         end
       end
 
@@ -124,10 +124,9 @@ module MCollective
 
       # we want to sync branches that are not ignored and are
       # not going to be removed
-      def branches_in_repo_to_sync
-        git_refs_hash.keys.reject do |branch|
-          remove_branches.any? { |r| r.match(branch) } or
-          ignore_branches.any? { |r| r.match(branch) }
+      def branches_in_repo_to_sync(updated_refs=nil)
+        (updated_refs || git_refs_hash.keys).reject do |branch|
+          (remove_branches + ignore_branches).any? { |r| r.match(branch) }
         end
       end
 

--- a/agent/puppetupdate.rb
+++ b/agent/puppetupdate.rb
@@ -117,19 +117,27 @@ module MCollective
           path = "#{env_dir}/#{dir}"
 
           if ref.nil? || sha.nil?
-            Log.info "  removing #{dir} / #{ref} / #{sha} - nils"
-            run "rm -rf #{path}"
+            if File.exists? path
+              Log.info "  removing #{dir} / #{ref} / #{sha} - nils"
+              run "rm -rf #{path}"
+            end
           elsif ignore_branches.any? {|r| dir =~ r || ref =~ r}
             Log.info "  ignoring #{dir} / #{ref} - matches ignore_branches"
           elsif remove_branches.any? {|r| dir =~ r || ref =~ r}
-            Log.info "  removing #{dir} - matches remove_branches"
-            run "rm -rf #{path}"
+            if File.exists? path
+              Log.info "  removing #{dir} - matches remove_branches"
+              run "rm -rf #{path}"
+            end
           elsif dir != ref_to_dir(ref)
-            Log.info "  removing #{dir} - #{ref_to_dir(ref)} != #{ref}"
-            run "rm -rf #{path}"
+            if File.exists? path
+              Log.info "  removing #{dir} - #{ref_to_dir(ref)} != #{ref}"
+              run "rm -rf #{path}"
+            end
           elsif !git[ref]
-            Log.info "  removing #{dir} - gone from repo"
-            run "rm -rf #{path}"
+            if File.exists? path
+              Log.info "  removing #{dir} - gone from repo"
+              run "rm -rf #{path}"
+            end
           elsif sha != git[ref]
             Log.info "  syncing #{dir} - #{sha}..#{git[ref]}"
             reset_ref(ref, git[ref])
@@ -147,13 +155,17 @@ module MCollective
           path = "#{env_dir}/#{dir}"
 
           if ref.nil? || sha.nil?
-            Log.info "  removing #{dir} - '#{ref}':'#{sha}' nils"
-            run "rm -rf #{path}" if File.exists?(path)
+            if File.exists? path
+              Log.info "  removing #{dir} - '#{ref}':'#{sha}' nils"
+              run "rm -rf #{path}"
+            end
           elsif ignore_branches.any? {|r| dir =~ r || ref =~ r}
             Log.info "  ignoring #{dir} / #{ref} - matches ignore_branches"
           elsif remove_branches.any? {|r| dir =~ r || ref =~ r}
-            Log.info "  removing #{dir} / #{ref} - matches remove_branches"
-            run "rm -rf #{path}"
+            if File.exists? path
+              Log.info "  removing #{dir} / #{ref} - matches remove_branches"
+              run "rm -rf #{path}"
+            end
           else
             Log.info "  deploying #{dir} / #{ref} / #{sha}"
             reset_ref(ref, sha)

--- a/agent/puppetupdate.rb
+++ b/agent/puppetupdate.rb
@@ -132,7 +132,7 @@ module MCollective
 
           if ref.nil? || sha.nil?
             Log.info "removing #{dir} - ref: '#{ref}' sha: '#{sha}'"
-            run "rm -rf #{path}"
+            run "rm -rf #{path}" if File.exists?(path)
           elsif ignore_branches.any? {|r| dir =~ r || ref =~ r}
             Log.info "ignoring #{dir} - matches ignore_branches"
           elsif remove_branches.any? {|r| dir =~ r || ref =~ r}

--- a/agent/puppetupdate.rb
+++ b/agent/puppetupdate.rb
@@ -54,6 +54,7 @@ module MCollective
           resolve(git_state, env_state)
         end
       end
+      alias update_all_branches update_all_refs
 
       def update_single_ref(ref, revision)
         whilst_locked do
@@ -61,6 +62,7 @@ module MCollective
           reset_ref(ref, revision == '' ? git_state[ref] : revision)
         end
       end
+      alias update_single_branch update_single_ref
 
       def ensure_dirs_and_fetch
         run "mkdir -p #{env_dir}" unless File.directory?(env_dir)

--- a/bin/debug
+++ b/bin/debug
@@ -5,8 +5,8 @@ require 'mcollective/pluginmanager'
 MCollective::Config.instance.loadconfig('spec/server.cfg')
 MCollective::PluginManager.find("agent")
 MCollective::PluginManager.loadclass('MCollective::Agent::Puppetupdate')
-if branch = ARGV.first
-  MCollective::Agent::Puppetupdate.new.update_single_branch branch
+if ref = ARGV.first
+  MCollective::Agent::Puppetupdate.new.update_single_ref ref
 else
-  MCollective::Agent::Puppetupdate.new.update_all_branches
+  MCollective::Agent::Puppetupdate.new.update_all_refs
 end

--- a/bin/debug
+++ b/bin/debug
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+require 'mcollective'
+require 'mcollective/pluginmanager'
+
+MCollective::Config.instance.loadconfig('spec/server.cfg')
+MCollective::PluginManager.find("agent")
+MCollective::PluginManager.loadclass('MCollective::Agent::Puppetupdate')
+if branch = ARGV.first
+  MCollective::Agent::Puppetupdate.new.update_single_branch branch
+else
+  MCollective::Agent::Puppetupdate.new.update_all_branches
+end

--- a/bin/puppetupdate
+++ b/bin/puppetupdate
@@ -5,8 +5,8 @@ require 'mcollective/pluginmanager'
 MCollective::Config.instance.loadconfig('/etc/mcollective/server.cfg')
 MCollective::PluginManager.find("agent")
 MCollective::PluginManager.loadclass('MCollective::Agent::Puppetupdate')
-if branch = ARGV.first
-  MCollective::Agent::Puppetupdate.new.update_single_branch branch
+if ref = ARGV.first
+  MCollective::Agent::Puppetupdate.new.update_single_ref ref
 else
-  MCollective::Agent::Puppetupdate.new.update_all_branches
+  MCollective::Agent::Puppetupdate.new.update_all_ref
 end

--- a/spec/plugins/agent/puppetupdate_spec.rb
+++ b/spec/plugins/agent/puppetupdate_spec.rb
@@ -24,6 +24,7 @@ describe MCollective::Agent::Puppetupdate do
       "puppetupdate",
       :agent_file => "#{File.dirname(__FILE__)}/../../../agent/puppetupdate.rb",
       :config     => {
+        "logger_type" => "console",
         "plugin.puppetupdate.directory" => Dir.mktmpdir,
         "plugin.puppetupdate.repository" => Dir.mktmpdir,
         "plugin.puppetupdate.lock_file" => "/tmp/puppetupdate_spec.lock",
@@ -54,7 +55,7 @@ describe MCollective::Agent::Puppetupdate do
     clone_bare
     Dir.mkdir(agent.env_dir)
 
-    agent.update_all_branches
+    agent.update_all_refs
   end
 
   after(:all) do
@@ -64,18 +65,166 @@ describe MCollective::Agent::Puppetupdate do
     SHELL
   end
 
+  describe '#update_all_refs'
+  describe '#update_single_ref'
+  describe '#ensure_repo_and_fetch'
+  describe '#git_state'
+  describe '#env_state'
+  describe '#resolve'
+  describe '#run_after_checkout!'
+  describe '#link_env_conf!'
+  describe '#reset_ref' do
+    it 'reads current ref status if not passed'
+    it 'reports from as 0-commit if failed to read'
+    it 'calls git_reset with correct args'
+    it 'calls link_env_conf as per config'
+    it 'calls run_after_checkout as per config'
+    it 'returns array in form [to, from, rev, link, after]'
+  end
+
+  describe '#git_reset' do
+    let(:path) { agent.ref_path 'master' }
+
+    it 'creates work tree dir' do
+      system "rm -rf #{path}"
+      agent.git_reset('master', 'master')
+      File.exists?(path).should be_true
+    end
+
+    it 'checksout repo into work tree' do
+      agent.git_reset('master', 'master')
+      File.read("#{path}/initial").should eq("initial\n")
+    end
+
+    it 'cleans work tree' do
+      system("mkdir -p #{path}")
+      File.write("#{path}/dirty", "dirty")
+      agent.git_reset('master', 'master', path)
+      File.exists?("#{path}/dirty").should be_false
+    end
+
+    it 'creates .git_revision and .git_ref' do
+      agent.git_reset('something', 'master', path)
+      File.read("#{path}/.git_revision").should eq("master")
+      File.read("#{path}/.git_ref").should eq("something")
+    end
+  end
+
+  describe '#ref_path' do
+    it 'is env_dir plus ref_to_dir' do
+      agent.expects(:env_dir).twice
+      agent.expects(:ref_to_dir).with('master').returns('masterbranch')
+      agent.ref_path('master').should eq("#{agent.env_dir}/masterbranch")
+    end
+  end
+
+  describe '#ref_to_dir' do
+    it 'replaces / with __' do
+      agent.branch_dir('fo/bar').should eq('fo__bar')
+    end
+
+    it 'returns original name if its good' do
+      agent.branch_dir('foobar').should eq('foobar')
+    end
+
+    it 'appends "branch" when reserved name' do
+      agent.branch_dir('master').should eq('masterbranch')
+      agent.branch_dir('user').should   eq('userbranch')
+      agent.branch_dir('agent').should  eq('agentbranch')
+      agent.branch_dir('main').should   eq('mainbranch')
+    end
+  end
+
+  describe '#git_auth' do
+    it 'creates ssh wrapper' do
+      agent.stubs(:config => "hello")
+      agent.git_auth do
+        File.exists?(ENV['GIT_SSH']).should be(true)
+        File.read(ENV['GIT_SSH']).should match(/hello/m)
+      end
+    end
+
+    it 'cleans up after yield' do
+      agent.stubs(:config => "hello")
+      file_name = agent.git_auth { ENV['GIT_SSH'] }
+      File.exists?(file_name).should be(false)
+    end
+
+    it 'sets env var yields and restores env' do
+      agent.stubs(:config => "hello")
+      with_git_ssh('not_matching') do
+        agent.git_auth { ENV['GIT_SSH'].should match(/ssh_wrapper/) }
+      end
+    end
+
+    it 'yields without touching env without ssh_key' do
+      agent.stubs(:config => nil)
+      with_git_ssh('anything') do
+        agent.git_auth { ENV['GIT_SSH'].should eq('anything') }
+      end
+    end
+
+    def with_git_ssh(value)
+      old_value = ENV['GIT_SSH']
+      ENV['GIT_SSH'] = value
+      yield
+    ensure
+      ENV['GIT_SSH'] = old_value
+    end
+  end
+
+  describe '#run' do
+    it 'returns output' do
+      agent.run("echo hello").should eq("hello\n")
+    end
+
+    it 'redirects err to out' do
+      agent.run("(echo hello >&2)").should eq("hello\n")
+    end
+
+    it 'fails with message' do
+      agent.expects(:fail).returns nil
+      agent.run("false")
+    end
+  end
+
+  describe '#whilst_locked' do
+    it 'uses lock_file config value' do
+      agent.expects(:lock_file).returns("lock")
+      File.expects(:open).with {|arg1| arg1 == "lock"}
+      agent.send(:whilst_locked) {}
+    end
+
+    it 'creates lock file and locks it' do
+      lock_stub = stub
+      lock_stub.expects(:flock)
+      File.expects(:open).yields(lock_stub)
+      agent.send(:whilst_locked) {}
+    end
+
+    it 'returns yielded result' do
+      expect { agent.send(:whilst_locked) { "hello" }.to eq("hello")}
+    end
+  end
+
+  describe '#regexy_string' do
+    it 'wraps generic string in ^$' do
+      agent.send(:regexy_string, "hi").should == /^hi$/
+    end
+
+    it 'recognizes regexy string' do
+      agent.send(:regexy_string, "/hi/").should == /hi/
+    end
+  end
+
+  # OLD
+
   it "#branches_in_repo_to_sync works" do
-    agent.stubs(:git_refs_hash => {'foo' => nil, 'bar' => nil, 'leave_me_alone' => nil})
+    agent.stubs(:git_state => {'foo' => nil, 'bar' => nil, 'leave_me_alone' => nil})
     agent.branches_in_repo_to_sync.should == ['foo', 'bar']
   end
 
   it "#branch_dir is not using reserved branch" do
-    agent.branch_dir('fo/bar').should eq('fo__bar')
-    agent.branch_dir('foobar').should eq('foobar')
-    agent.branch_dir('master').should eq('masterbranch')
-    agent.branch_dir('user').should   eq('userbranch')
-    agent.branch_dir('agent').should  eq('agentbranch')
-    agent.branch_dir('main').should   eq('mainbranch')
   end
 
   describe "#update_bare_repo" do

--- a/spec/plugins/agent/puppetupdate_spec.rb
+++ b/spec/plugins/agent/puppetupdate_spec.rb
@@ -99,7 +99,6 @@ describe MCollective::Agent::Puppetupdate do
     `mkdir -p #{agent.env_dir}/hahah`
     agent.drop_bad_dirs
     File.exist?("#{agent.env_dir}/hahah").should == false
-    File.exist?("#{agent.env_dir}/masterbranch").should == true
   end
 
   it '#drop_bad_dirs does not remove ignored branches' do
@@ -109,13 +108,13 @@ describe MCollective::Agent::Puppetupdate do
   end
 
   it '#drop_bad_dirs does cleanup removed branches' do
-    File.exist?("#{agent.env_dir}/must_be_removed").should == false
     `mkdir -p #{agent.env_dir}/must_be_removed`
     agent.drop_bad_dirs
     File.exist?("#{agent.env_dir}/must_be_removed").should == false
   end
 
   it 'checks out an arbitrary Git hash from a fresh repo' do
+    agent.update_single_branch("master")
     previous_rev = `cd #{agent.dir}/puppet.git; git rev-list master --max-count=1 --skip=1`.chomp
     File.write("#{agent.env_dir}/masterbranch/touch", "touch")
     agent.update_single_branch("master", previous_rev)

--- a/spec/plugins/agent/puppetupdate_spec.rb
+++ b/spec/plugins/agent/puppetupdate_spec.rb
@@ -153,12 +153,14 @@ describe MCollective::Agent::Puppetupdate do
 
     context 'env resolutions' do
       it 'removes when ref is nil' do
+        expect(File).to receive(:exists?).and_return true
         expect(Log).to receive(:info).with(/removing/).once
         expect(agent).to receive(:run)
         agent.resolve({}, {"dir" => [nil, "sha"]})
       end
 
       it 'removes when sha is nil' do
+        expect(File).to receive(:exists?).and_return true
         expect(Log).to receive(:info).with(/removing/)
         expect(agent).to receive(:run)
         agent.resolve({}, {"dir" => ["ref"]})
@@ -180,6 +182,7 @@ describe MCollective::Agent::Puppetupdate do
 
       it 'removes when dir matches remove_branches' do
         allow(agent).to receive(:remove_branches).and_return([/ref/])
+        expect(File).to receive(:exists?).and_return true
         expect(Log).to receive(:info).with(/matches remove/)
         expect(agent).to receive(:run)
         agent.resolve({}, {"dir" => ["ref", "sha"]})
@@ -187,18 +190,21 @@ describe MCollective::Agent::Puppetupdate do
 
       it 'removes when ref matches remove_branches' do
         allow(agent).to receive(:remove_branches).and_return([/ref/])
+        expect(File).to receive(:exists?).and_return true
         expect(Log).to receive(:info).with(/matches remove/)
         expect(agent).to receive(:run)
         agent.resolve({}, {"dir" => ["ref", "sha"]})
       end
 
       it 'removes when dir doesnt match ref_to_dir(ref)' do
+        expect(File).to receive(:exists?).and_return true
         expect(Log).to receive(:info).with(/removing.*!=/)
         expect(agent).to receive(:run)
         agent.resolve({}, {"dir" => ["ref", "sha"]})
       end
 
       it 'removes when ref not found in git refs' do
+        expect(File).to receive(:exists?).and_return true
         expect(Log).to receive(:info).with(/gone from repo/)
         expect(agent).to receive(:run)
         agent.resolve({}, {"dir" => ["dir", "sha"]})
@@ -247,6 +253,7 @@ describe MCollective::Agent::Puppetupdate do
 
       it 'removes when dir matches remove_branches' do
         allow(agent).to receive(:remove_branches).and_return([/ref/])
+        expect(File).to receive(:exists?).and_return true
         expect(Log).to receive(:info).with(/matches remove/)
         expect(agent).to receive(:run)
         agent.resolve({"ref" => "sha"}, {})
@@ -255,6 +262,7 @@ describe MCollective::Agent::Puppetupdate do
       it 'removes when ref matches remove_branches' do
         allow(agent).to receive(:remove_branches).and_return([/dir/])
         allow(agent).to receive(:ref_to_dir).and_return("dir")
+        expect(File).to receive(:exists?).and_return true
         expect(Log).to receive(:info).with(/matches remove/)
         expect(agent).to receive(:run)
         agent.resolve({"ref" => "sha"}, {})

--- a/spec/plugins/agent/puppetupdate_spec.rb
+++ b/spec/plugins/agent/puppetupdate_spec.rb
@@ -148,7 +148,7 @@ describe MCollective::Agent::Puppetupdate do
 
   describe '#resolve' do
     before(:each) do
-      allow(Log).to receive(:info).with(/inspecting/)
+      allow(Log).to receive(:info)
     end
 
     context 'env resolutions' do

--- a/spec/server.cfg.example
+++ b/spec/server.cfg.example
@@ -4,8 +4,8 @@
 main_collective = mcollective
 collectives = mcollective
 libdir = .
-logfile = tmp/mcollective.log
-loglevel = debug
+logger_type = console
+loglevel = info
 daemonize = 0
 identity = dev1-devb.dev.yelpcorp.com
 

--- a/spec/server.cfg.example
+++ b/spec/server.cfg.example
@@ -1,0 +1,18 @@
+# This is example file, copy it without .example and
+# set all paths to be non-relative.
+
+main_collective = mcollective
+collectives = mcollective
+libdir = .
+logfile = tmp/mcollective.log
+loglevel = debug
+daemonize = 0
+identity = dev1-devb.dev.yelpcorp.com
+
+plugin.puppetupdate.directory = tmp/puppet
+plugin.puppetupdate.repository = git@yourgit.com:puppet
+plugin.puppetupdate.rewrite_config = false
+plugin.puppetupdate.ignore_branches = production
+plugin.puppetupdate.remove_branches = /^(u(ser)?|
+plugin.puppetupdate.link_env_conf = true
+# plugin.puppetupdate.release_tags = /^r/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,6 @@ $: << File.join([File.dirname(__FILE__), "lib"])
 require 'rubygems'
 require 'rspec'
 require 'mcollective/test'
-require 'rspec/mocks'
-require 'mocha'
 require 'tempfile'
 
 module MCollective::Test::Util::Validator
@@ -12,10 +10,6 @@ module MCollective::Test::Util::Validator
 end
 
 RSpec.configure do |config|
-  config.mock_with :mocha
   config.include(MCollective::Test::Matchers)
-
-  config.before :each do
-    MCollective::PluginManager.clear
-  end
+  config.before(:each) { MCollective::PluginManager.clear }
 end


### PR DESCRIPTION
- sync/deploy also tags, not only branches
- cleaner/separate logic that deals with existing envs and git refs
- store ref/sha in each deployment
- bundle exec bin/debug for local testing
- bump rspec and fork mcollective-test to work with it
- cover all functionality with specs