### PR TITLE
No backticks and more

### DIFF
--- a/agent/puppetupdate.rb
+++ b/agent/puppetupdate.rb
@@ -44,7 +44,9 @@ module MCollective
       end
 
       action "git_gc" do
-        run ["git --git-dir=%s gc --auto --prune", git_dir], "Pruning git repo"
+        whilst_locked do
+          run ["git --git-dir=%s gc --auto --prune", git_dir], "Pruning git repo"
+        end
       end
 
       def update_all_refs
@@ -63,43 +65,50 @@ module MCollective
       end
       alias update_single_branch update_single_ref
 
+      def git_cmd(cmd, *rest)
+        ["git --git-dir=%s " << cmd, git_dir, *rest]
+      end
+
       def ensure_dirs_and_fetch
         run ["mkdir -p %s", env_dir] unless File.directory?(env_dir)
-        g = "git --git-dir=#{git_dir.shellescape}"
 
-        if `#{g} config core.bare 2>/dev/null`.strip != "true"
-          Log.warn("Invalid repo config in #{git_dir}, re-created")
-          run ["rm -rf %s && mkdir -p %s && #{g} init --bare", git_dir, git_dir]
+        if run(git_cmd('config core.bare || echo false')).to_s.strip != "true"
+          run ["rm -rf %s && mkdir -p %s", git_dir, git_dir],
+              "Invalid repo config in #{git_dir}, re-created",
+              :warn
+          run(git_cmd('init --bare'), "Initialized bare repo")
         end
 
-        if `#{g} config remote.origin.url 2>/dev/null`.strip != repo_url ||
-           `#{g} config remote.origin.mirror 2>/dev/null`.strip != "true"
+        config_repo_url = run(git_cmd('config remote.origin.url || echo false')).to_s.strip
+        config_mirror = run(git_cmd('config remote.origin.url || echo false')).to_s.strip
+
+        if config_repo_url != repo_url || config_mirror != "true"
           Log.warn("Invalid remote config in #{git_dir}, re-created")
-          run "#{g} remote remove origin || true"
-          run ["#{g} remote add origin --mirror=fetch %s", repo_url]
+          run git_cmd("remote remove origin || true")
+          run git_cmd("remote add origin --mirror=fetch %s", repo_url)
         end
 
         git_auth do
-          run "#{g} fetch --tags --prune origin", "Fetching git repo"
+          run git_cmd("fetch --tags --prune origin"), "Fetching git repo"
         end
       end
 
-      # Returns hash in form refs => sha.
+      # Returns hash in form {refs => sha, ...}.
       def git_state
         if @git_state
           Log.info "Cached git state"
           @git_state
         else
           Log.info "Reading git state"
-          ref_parse = %r{^(\w+)\s+refs/(heads?|tags)/([\w/\-_]+)(\^\{\})?$}
-          @git_state = `git --git-dir=#{git_dir.shellescape} show-ref \
-                            --dereference 2>/dev/null`.lines.inject({}) do |agg, line|
+          ref_parse  = %r{^(\w+)\s+refs/(heads?|tags)/([\w/\-_]+)(\^\{\})?$}
+          git_refs   = run(git_cmd("show-ref --dereference")).lines
+          @git_state = git_refs.inject({}) do |agg, line|
             agg.merge!(line =~ ref_parse ? {$3 => $1} : {})
           end
         end
       end
 
-      # Returns hash in form dir => [ref, sha]
+      # Returns hash in form {dir => [ref, sha], ...}
       def env_state
         Log.info "Reading environment state"
         Dir.entries(env_dir).
@@ -158,10 +167,9 @@ module MCollective
                 run ["rm -rf %s", path]
               end
             elsif sha != git[ref]
-              msg = "synced #{dir} - #{sha}..#{git[ref]}"
+              msg = reset_ref(ref, git[ref])
               Log.info msg
               changes << msg
-              reset_ref(ref, git[ref])
               git.delete ref
             else
               Log.debug "in-sync #{dir}"
@@ -192,16 +200,15 @@ module MCollective
               Log.info "  ignoring #{dir} / #{ref} - matches ignore_branches"
             elsif remove_branches.any? {|r| dir =~ r || ref =~ r}
               if File.exists? path
+                run ["rm -rf %s", path]
                 msg = "removed #{dir} / #{ref} - matches remove_branches"
                 Log.info msg
                 changes << msg
-                run ["rm -rf %s", path]
               end
             else
-              msg = "deployed #{dir} / #{ref} / #{sha}"
+              msg = reset_ref(ref, sha)
               Log.info msg
               changes << msg
-              reset_ref(ref, sha)
             end
           rescue => err
             msg = "#{ref} env resolve: #{err.message} [#{err.backtrace.join ', '}]"
@@ -214,13 +221,25 @@ module MCollective
       end
 
       def reset_ref(ref, revision, from=nil)
-        from ||= File.read("#{ref_path(ref)}/.git_revision") rescue '000000'
-        git_reset(ref, revision)
+        from ||= File.read("#{ref_path(ref)}/.git_revision") rescue '00000000'
 
-        linked = link_env_conf ? link_env_conf!(ref) : nil
-        after_checkout = run_after_checkout ? run_after_checkout!(ref) : nil
+        if revision =~ /^0+$/
+          work_tree = ref_path(ref)
+          run ["rm -rf %s", work_tree]
+          "#{ref}: deleted (was #{from[0..8]} in #{work_tree})"
+        else
+          revision ||= git_state[revision]
+          fail "can't reset #{ref} to empty revision" unless revision
 
-        "#{ref}: #{from}..#{revision} in #{ref_path(ref)} (linked env.conf: #{!!linked}, after checkout: #{!!after_checkout})"
+          git_reset(ref, revision)
+
+          linked = link_env_conf ? link_env_conf!(ref) : nil
+          after_checkout = run_after_checkout ? run_after_checkout!(ref) : nil
+
+          "#{ref}: #{from}..#{revision} in #{ref_path(ref)}, " <<
+            "linked env.conf: #{!!linked}, " <<
+            "after checkout: #{after_checkout.success? ? 'success' : 'fail'}"
+        end
       rescue => err
         "#{ref}: #{from}..#{revision} failed: #{err.message} [#{err.backtrace.join ', '}]"
       end
@@ -228,7 +247,6 @@ module MCollective
       def link_env_conf!(ref)
         if File.exists?(global_env_conf = "#{dir}/environment.conf") &&
            !File.exists?(local_env_conf = "#{ref_path(ref)}/environment.conf")
-          # Log.info "  linked #{global_env_conf} -> #{local_env_conf}"
           run ["ln -s %s %s", global_env_conf, local_env_conf]
         end
       end
@@ -238,11 +256,7 @@ module MCollective
           tap {|result| Log.info "  after checkout is #{result}" }
       end
 
-      def git_reset(ref, revision=nil)
-        revision ||= git_state[ref]
-        unless revision
-          fail "revision '#{revision}' for a ref '#{ref}' not found in git state"
-        end
+      def git_reset(ref, revision)
         work_tree = ref_path(ref)
         run ["mkdir -p %s", work_tree] unless File.exists?(work_tree)
         run ["git --git-dir=%s --work-tree=%s checkout --detach --force %s", git_dir, work_tree, revision]
@@ -288,7 +302,7 @@ module MCollective
         Log.send level, msg if msg
         cmd = "#{cmd.first % cmd[1..-1].map(&:shellescape)}" if cmd.is_a? Array
         output = `(#{cmd}) 2>&1`
-        fail "#{cmd} failed with: #{output}" unless $?.success?
+        fail "#{cmd} failed: #{output}" unless $?.success?
         output
       end
 

--- a/application/puppetupdate.rb
+++ b/application/puppetupdate.rb
@@ -4,19 +4,24 @@ class MCollective::Application::Puppetupdate < MCollective::Application
 
   def post_option_parser(configuration)
     if ARGV.length >= 1
-      configuration[:command]  = ARGV.shift
+      configuration[:command] = ARGV.shift
       unless configuration[:command] =~ /^update(_all)?$/
         STDERR.puts "Don't understand command '#{configuration[:command]}', please use update <branch> [<sha1>] or update_all"
         exit 1
       end
-      configuration[:branch]   = ARGV.shift
-      if configuration[:command] == 'update' && configuration[:branch].nil?
-        STDERR.puts "Don't understand update without a branch name"
-        exit 1
+
+      if configuration[:command] == 'update'
+        configuration[:branch] = ARGV.shift
+
+        if configuration[:branch].nil?
+          STDERR.puts "Don't understand update without a branch name"
+          exit 1
+        end
+
+        configuration[:revision] = ARGV.shift || ''
       end
-      configuration[:revision] = ARGV.shift || ''
     else
-      STDERR.puts "Please specify an action (update <branch>|update_all) on the command line"
+      STDERR.puts "Please specify an action (update <branch> [<sha1>]|update_all) on the command line"
       exit 1
     end
   end

--- a/spec/plugins/agent/puppetupdate_spec.rb
+++ b/spec/plugins/agent/puppetupdate_spec.rb
@@ -211,10 +211,10 @@ describe MCollective::Agent::Puppetupdate do
       end
 
       it 'resets when sha doesnt match git ref' do
-        expect(Log).to receive(:info).with(/sha1\.\.sha2/)
-        expect(agent).to receive(:reset_ref)
+        expect(agent).to receive(:reset_ref).with('dir', 'sha2')
         git_state = {"dir" => "sha2"}
-        agent.resolve(git_state, {"dir" => ["dir", "sha1"]})
+        env_state = {"dir" => ["dir", "sha1"]}
+        changes = agent.resolve(git_state, env_state)
         expect(git_state).to be_empty
       end
 
@@ -365,6 +365,11 @@ describe MCollective::Agent::Puppetupdate do
         :run_after_checkout => true)
       expect(agent).to receive(:run_after_checkout!)
       agent.reset_ref('ref', 'rev', 'from')
+    end
+
+    it 'removes the environment when target is 00000000' do
+      allow(agent).to receive(:run).with(["rm -rf %s", agent.ref_path('ref')])
+      agent.reset_ref('ref', '00000000')
     end
   end
 

--- a/spec/plugins/agent/puppetupdate_spec.rb
+++ b/spec/plugins/agent/puppetupdate_spec.rb
@@ -280,13 +280,24 @@ describe MCollective::Agent::Puppetupdate do
     before { agent.update_all_refs }
 
     it 'chdirs into ref path' do
+      allow(agent).to receive(:run_after_checkout).and_return("true")
       expect(Dir).to receive(:chdir).with(agent.ref_path('master'))
       agent.run_after_checkout!('master')
     end
 
-    it 'systems the callback and returns exit status' do
+    it 'systems the callback and returns happy status' do
       allow(agent).to receive(:run_after_checkout).and_return("true")
       expect(agent.run_after_checkout!('master')).to be(true)
+    end
+
+    it 'systems the callback and returns sad status' do
+      allow(agent).to receive(:run_after_checkout).and_return("false")
+      expect(agent.run_after_checkout!('master')).to be(false)
+    end
+
+    it 'returns nil if not configured to run' do
+      allow(agent).to receive(:run_after_checkout).and_return(nil)
+      expect(agent.run_after_checkout!('master')).to be_nil
     end
   end
 
@@ -370,6 +381,12 @@ describe MCollective::Agent::Puppetupdate do
     it 'removes the environment when target is 00000000' do
       allow(agent).to receive(:run).with(["rm -rf %s", agent.ref_path('ref')])
       agent.reset_ref('ref', '00000000')
+    end
+
+    it 'noop when from == to' do
+      allow(agent).to receive(:run).never
+      allow(agent).to receive(:git_reset).never
+      expect(agent.reset_ref('ref', '123', '123')).to eq("ref: in sync @ 123")
     end
   end
 


### PR DESCRIPTION
- replace all backtick with `#run`
- cleanup args parsing code a bit
- remove deployed environment when target revision is `/^0+$/`
- show short shas everywhere for readability
- noop in reset_ref when `from` == `revision`