### PR TITLE
Deployment expiration

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,5 @@
 
 set -eu
 
+bundle install
 bundle exec rake spec


### PR DESCRIPTION
- add config option expire_after_days
- remove deployments where .git_revision file mtime is too old
- do not deploy branches where latest commit is too old
- add specs