### PR TITLE
PEAUTO-455 Add dont_expire_branches config option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM docker-dev.yelpcorp.com/trusty_yelp:latest
+FROM docker-dev.yelpcorp.com/xenial_yelp:latest
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates git ruby ruby-dev mcollective-omnibus=2.8.8-77 git \
+        ca-certificates git ruby ruby-dev mcollective-omnibus=2.8.8-20190311164112 git \
         devscripts build-essential fakeroot debhelper cdbs dpatch \
     && apt-get clean
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ To force-deploy an old branch run `update` action on it directly.
 
 Defaults to `30`. Value `0` will disable expiration functionality.
 
+## dont_expire_branches
+
+When running `update_all` action, do not expire these deployments even
+if they are older than `expire_after_days`.
+
 # Installation
 
 Requires docker to build .debs. Checkout, then just run:


### PR DESCRIPTION
This change is to add a new config option (`dont_expire_branches`) to be used when you don't want
to expire some branches, even if they hit the `expire_after_days` timeout.

`dont_expire_branches` is an alternative to `ignore_branches`, as the later doesn't update branches when the `update_all` command is executed.