### PR TITLE
PEAUTO-860 Improve checkout performance

### DIFF
--- a/agent/puppetupdate.rb
+++ b/agent/puppetupdate.rb
@@ -93,7 +93,7 @@ module MCollective
         end
 
         git_auth do
-          run git_cmd("fetch --tags --prune origin"), "Fetching git repo"
+          run git_cmd("fetch --depth 1 --tags --prune origin"), "Fetching git repo"
         end
       end
 


### PR DESCRIPTION
This change adds the flag '--depth 1' to the git-fetch command.
Manual tests proved that this improves the checkout performance by 33%.